### PR TITLE
getFile() can return a null, which causes an NPE

### DIFF
--- a/cxf-xjc-plugin/src/main/java/org/apache/cxf/maven_plugin/AbstractXSDToJavaMojo.java
+++ b/cxf-xjc-plugin/src/main/java/org/apache/cxf/maven_plugin/AbstractXSDToJavaMojo.java
@@ -258,7 +258,7 @@ public abstract class AbstractXSDToJavaMojo extends AbstractMojo {
         }
     }
     
-    private List<File> resolve(String artifactDescriptor) {
+    private List<File> resolve(String artifactDescriptor) throws MojoExecutionException {
         String[] s = artifactDescriptor.split(":");
 
         String type = s.length >= 4 ? s[3] : "jar";
@@ -281,7 +281,10 @@ public abstract class AbstractXSDToJavaMojo extends AbstractMojo {
         ArtifactResolutionResult result = repository.resolve(request);
         List<File> files = new ArrayList<File>();
         for (Artifact a : result.getArtifacts()) {
-            files.add(a.getFile());
+            if (a.getFile() == null) {
+                throw new MojoExecutionException("Unable to resolve " + a.toString()
+                        + " while resolving " + artifactDescriptor);
+            }
         }
         if (!files.contains(artifact.getFile())) {
             files.add(artifact.getFile());


### PR DESCRIPTION
While building CXF i encountered an NPE (see below.) It appears to be possible for org.apache.maven.artifact.Artifact.getFile() to return a null, which will trigger the NPE in AbstractXSDToJavaMojo.getArguments. It should throw a MojoExecutionException telling the user that it was unable to resolve a dependency.

```
[ERROR] Failed to execute goal org.apache.cxf:cxf-xjc-plugin:3.0.2:xsdtojava (generate-sources) on project cxf-core: Could not download extension artifact: NullPointerException -> [Help 1]
org.apache.maven.lifecycle.LifecycleExecutionException: Failed to execute goal org.apache.cxf:cxf-xjc-plugin:3.0.2:xsdtojava (generate-sources) on project cxf-core: Could not download extension artifact
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:216)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:153)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:145)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:116)
	at org.apache.maven.lifecycle.internal.LifecycleModuleBuilder.buildProject(LifecycleModuleBuilder.java:80)
	at org.apache.maven.lifecycle.internal.builder.singlethreaded.SingleThreadedBuilder.build(SingleThreadedBuilder.java:51)
	at org.apache.maven.lifecycle.internal.LifecycleStarter.execute(LifecycleStarter.java:128)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:307)
	at org.apache.maven.DefaultMaven.doExecute(DefaultMaven.java:193)
	at org.apache.maven.DefaultMaven.execute(DefaultMaven.java:106)
	at org.apache.maven.cli.MavenCli.execute(MavenCli.java:862)
	at org.apache.maven.cli.MavenCli.doMain(MavenCli.java:286)
	at org.apache.maven.cli.MavenCli.main(MavenCli.java:197)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:497)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launchEnhanced(Launcher.java:289)
	at org.codehaus.plexus.classworlds.launcher.Launcher.launch(Launcher.java:229)
	at org.codehaus.plexus.classworlds.launcher.Launcher.mainWithExitCode(Launcher.java:415)
	at org.codehaus.plexus.classworlds.launcher.Launcher.main(Launcher.java:356)
Caused by: org.apache.maven.plugin.MojoExecutionException: Could not download extension artifact
	at org.apache.cxf.maven_plugin.AbstractXSDToJavaMojo.execute(AbstractXSDToJavaMojo.java:238)
	at org.apache.cxf.maven_plugin.XSDToJavaMojo.execute(XSDToJavaMojo.java:41)
	at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
	at org.apache.maven.lifecycle.internal.MojoExecutor.execute(MojoExecutor.java:208)
	... 20 more
Caused by: org.apache.maven.plugin.MojoExecutionException: Could not download extension artifact
	at org.apache.cxf.maven_plugin.AbstractXSDToJavaMojo.getArguments(AbstractXSDToJavaMojo.java:325)
	at org.apache.cxf.maven_plugin.AbstractXSDToJavaMojo.run(AbstractXSDToJavaMojo.java:288)
	at org.apache.cxf.maven_plugin.AbstractXSDToJavaMojo.execute(AbstractXSDToJavaMojo.java:225)
	... 23 more
Caused by: java.lang.NullPointerException
	at org.apache.cxf.maven_plugin.AbstractXSDToJavaMojo.getArguments(AbstractXSDToJavaMojo.java:320)
	... 25 more
```

