### PR TITLE
Convenience option for configuring the code generation from XSD files:

### DIFF
--- a/cxf-xjc-plugin/src/main/java/org/apache/cxf/maven_plugin/XsdOption.java
+++ b/cxf-xjc-plugin/src/main/java/org/apache/cxf/maven_plugin/XsdOption.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 public class XsdOption {
     String xsd;
+    String xsdDir;
     String packagename;
     String bindingFile;
     File dependencies[];
@@ -43,6 +44,12 @@ public class XsdOption {
     }
     public void setXsd(String x) {
         this.xsd = x;
+    }
+    public String getXsdDir() {
+        return xsdDir;
+    }
+    public void setXsdDir(String x) {
+        this.xsdDir = x;
     }
     public String getBindingFile() {
         return bindingFile;


### PR DESCRIPTION
Instead of having to explicitly list every single file using the '<xsd>'
element, now the new '<xsdDir>' element can be used instead for
specifying a directory. From this directory all '*.xsd' files will be
used for code generation.

See also the ticket I opened in JIRA: https://issues.apache.org/jira/browse/CXFXJC-11