### PR TITLE
[CXFXJC-14] Anonymous enum simpleType causes NPE

### DIFF
--- a/javadoc/src/main/java/org/apache/cxf/xjc/javadoc/JavadocInserter.java
+++ b/javadoc/src/main/java/org/apache/cxf/xjc/javadoc/JavadocInserter.java
@@ -20,9 +20,12 @@ package org.apache.cxf.xjc.javadoc;
 
 import java.util.Collection;
 
+import javax.xml.namespace.QName;
+
 import org.xml.sax.ErrorHandler;
 
 import com.sun.tools.xjc.Options;
+import com.sun.tools.xjc.model.CEnumLeafInfo;
 import com.sun.tools.xjc.outline.ClassOutline;
 import com.sun.tools.xjc.outline.EnumOutline;
 import com.sun.tools.xjc.outline.FieldOutline;
@@ -87,11 +90,17 @@ public class JavadocInserter {
     }
 
     private boolean isCustomBindingApplied(EnumOutline enumOutline) {
-        String defaultComment = Messages.format("ClassSelector.JavadocHeading", enumOutline.target
-            .getTypeName().getLocalPart());
+        CEnumLeafInfo target = enumOutline.target;
+        QName typeName = target.getTypeName();
+        // typeName may be null on anonymous simple types
+        if (typeName == null) {
+            return false;
+        }
+        String defaultComment = Messages.format("ClassSelector.JavadocHeading",
+                typeName.getLocalPart());
         // not very clean but the only way of determining whether Javadoc
         // customization has been applied
-        return !enumOutline.target.javadoc.startsWith(defaultComment);
+        return !target.javadoc.startsWith(defaultComment);
     }
 
 }

--- a/javadoc/src/test/java/org/apache/cxf/xjc/javadoc/JavadocPluginTest.java
+++ b/javadoc/src/test/java/org/apache/cxf/xjc/javadoc/JavadocPluginTest.java
@@ -156,6 +156,16 @@ public class JavadocPluginTest extends Assert {
         assertThat(getterJavadoc, javadocContains("Documentation of attribute"));
     }
 
+    @Test
+    public void testAnonymousEnum() throws Exception {
+        String fileName = "anonymousEnum.xsd";
+        assertProcessedSuccessful(fileName, "-b", getAbsolutePath("anonymousEnum-javadoc-bindings.xjb"));
+
+        CompilationUnit compilationUnit = parseSourceFile("AnonymousTypesafeEnumClass.java");
+        Javadoc topLevelTypeJavadoc = getTopLevelEnum(compilationUnit).getJavadoc();
+        assertThat(topLevelTypeJavadoc, javadocContains("Documentation of anonymous enum simpleType"));
+    }
+
     private void assertProcessedSuccessful(String fileName, String... params) throws Exception {
         String xsdPath = getAbsolutePath(fileName);
         List<String> args = new ArrayList<String>(Arrays.asList(xsdPath, "-Xjavadoc", "-d", OUTPUT_DIR));

--- a/javadoc/src/test/resources/anonymousEnum-javadoc-bindings.xjb
+++ b/javadoc/src/test/resources/anonymousEnum-javadoc-bindings.xjb
@@ -1,0 +1,30 @@
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License. You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+ <jaxb:bindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
+	xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
+	xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
+	jaxb:version="2.1" schemaLocation="anonymousEnum.xsd"
+	node="/xs:schema">
+		
+	<jaxb:bindings node="./xs:element[@name='someElement']/xs:simpleType">
+		<jaxb:typesafeEnumClass name="AnonymousTypesafeEnumClass" />
+	</jaxb:bindings>
+
+</jaxb:bindings>

--- a/javadoc/src/test/resources/anonymousEnum.xsd
+++ b/javadoc/src/test/resources/anonymousEnum.xsd
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ Licensed to the Apache Software Foundation (ASF) under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. The ASF licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License. You may obtain a copy of the License at
+ 
+ http://www.apache.org/licenses/LICENSE-2.0
+ 
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied. See the License for the
+ specific language governing permissions and limitations
+ under the License.
+ -->
+ <schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:tns="http://www.example.org/xjc-javadoc-plugin/"
+ 	targetNamespace="http://www.example.org/xjc-javadoc-plugin/">
+
+	<element name="someElement">
+		<simpleType>
+			<annotation>
+				<documentation>Documentation of anonymous enum simpleType</documentation>
+			</annotation>
+			<restriction base="token">
+				<enumeration value="ONE"/>
+			</restriction>
+		</simpleType>
+	</element>
+
+</schema>


### PR DESCRIPTION
When I tried to use the Javadoc plugin on a certain XSD, it failed with a NPE. It is caused by a null TypeName object when trying to verify custom bindings for enums. A test case is included with example files, and the fix.

Link for this bug on JIRA: https://issues.apache.org/jira/browse/CXFXJC-14