### PR TITLE
Generate a help mojo for the cxf-xjc-plugin

### DIFF
--- a/cxf-xjc-plugin/pom.xml
+++ b/cxf-xjc-plugin/pom.xml
@@ -124,6 +124,12 @@
                             <goal>descriptor</goal>
                         </goals>
                     </execution>
+                    <execution>
+                        <id>generate-helpmojo</id>
+                        <goals>
+                            <goal>helpmojo</goal>
+                        </goals>
+                    </execution>
                 </executions>
             </plugin>
         </plugins>


### PR DESCRIPTION
Generate a help mojo for the cxf-xjc-plugin, so the user can get help regarding goals and parameters from the command line.

You can read more about how to use a help mojo here: https://maven.apache.org/plugin-tools/maven-plugin-plugin/help-mojo.html
