### PR TITLE
Javadoc multiline support improvements

### DIFF
--- a/javadoc/src/main/java/org/apache/cxf/xjc/javadoc/PropertyJavadoc.java
+++ b/javadoc/src/main/java/org/apache/cxf/xjc/javadoc/PropertyJavadoc.java
@@ -63,7 +63,7 @@ public class PropertyJavadoc {
         if (documentation == null || "".equals(documentation.trim())) {
             return;
         }
-        setJavadoc(documentation.trim());
+        setJavadoc(documentation.replaceAll("^\\s+|\\s+$|\\s*(\n)\\s*|(\\s)\\s*", "$1$2"));
     }
 
     private XSComponent getDocumentedComponent(CPropertyInfo propertyInfo) {

--- a/javadoc/src/test/resources/complexTypeWithDocumentedAttribute.xsd
+++ b/javadoc/src/test/resources/complexTypeWithDocumentedAttribute.xsd
@@ -28,5 +28,13 @@
 				<documentation>Documentation of attribute</documentation>
 			</annotation>
 		</attribute>
+		<attribute name="multilineDocumentedAttribute" type="string">
+			<annotation>
+				<documentation>
+                    Multiline documentation of
+                    attribute
+				</documentation>
+			</annotation>
+		</attribute>
 	</complexType>
 </schema>

--- a/javadoc/src/test/resources/complexTypeWithDocumentedProperties.xsd
+++ b/javadoc/src/test/resources/complexTypeWithDocumentedProperties.xsd
@@ -31,6 +31,14 @@
     		<element name="elementWithoutDocumentation" type="string">
     			<annotation></annotation>
     		</element>
+			<element name="multilineDocumentedElement" type="string">
+				<annotation>
+					<documentation>
+						Some multiline documentation of
+						element
+					</documentation>
+				</annotation>
+			</element>
     	</sequence>
     </complexType>
 </schema>


### PR DESCRIPTION
I found that if documentation block contains multiline comment similar to this:
```
<annotation>
	<documentation>
                    Multiline documentation of
                    attribute
	</documentation>
</annotation>
```
then generated javadoc looks sloppy. For the example above, it will be look like this:
>     /**
>      * Multiline documentation of
>      *                     attribute
>      * 
>      */
>     @XmlAttribute(name = "multilineDocumentedAttribute")
>     protected String multilineDocumentedAttribute;

Unfortunately, this problem cannot be identified during tests, because the compiled class org.eclipse.jdt.core.dom.Javadoc contains TagElement with a list of fragments without extra whitespaces.

Using solution from [here](https://stackoverflow.com/a/15495235), javadoc will transform into:
>     /**
>      * Multiline documentation of
>      * attribute
>      * 
>      */
>     @XmlAttribute(name = "multilineDocumentedAttribute")
>     protected String multilineDocumentedAttribute;