### PR TITLE
CXFXJC-40: Support Jakarta EE 9.0+

### DIFF
--- a/boolean-test/pom.xml
+++ b/boolean-test/pom.xml
@@ -27,7 +27,7 @@
 	<parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-		<version>3.3.2-SNAPSHOT</version>
+		<version>4.0.0-SNAPSHOT</version>
 	</parent>
 
     <dependencies>

--- a/boolean/pom.xml
+++ b/boolean/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
 

--- a/bug671/pom.xml
+++ b/bug671/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bug671/src/main/java/org/apache/cxf/xjc/bug671/Bug671Plugin.java
+++ b/bug671/src/main/java/org/apache/cxf/xjc/bug671/Bug671Plugin.java
@@ -19,12 +19,12 @@
 
 package org.apache.cxf.xjc.bug671;
 
-
 import com.sun.codemodel.JJavaName;
 import com.sun.tools.xjc.BadCommandLineException;
 import com.sun.tools.xjc.Options;
 import com.sun.tools.xjc.Plugin;
-import com.sun.xml.bind.api.impl.NameConverter;
+
+import org.glassfish.jaxb.core.api.impl.NameConverter;
 
 /**
  * Modifies the JAXB code model to handle package naming that run into:

--- a/bug986/pom.xml
+++ b/bug986/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/bug986/src/main/java/org/apache/cxf/xjc/bug986/Bug986Plugin.java
+++ b/bug986/src/main/java/org/apache/cxf/xjc/bug986/Bug986Plugin.java
@@ -29,7 +29,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import javax.xml.bind.annotation.XmlSchemaType;
 
 import org.xml.sax.ErrorHandler;
 
@@ -43,6 +42,8 @@ import com.sun.tools.xjc.Options;
 import com.sun.tools.xjc.Plugin;
 import com.sun.tools.xjc.outline.ClassOutline;
 import com.sun.tools.xjc.outline.Outline;
+
+import jakarta.xml.bind.annotation.XmlSchemaType;
 
 /**
  * Modifies the JAXB code model to handle package naming that run into:

--- a/cxf-xjc-plugin/pom.xml
+++ b/cxf-xjc-plugin/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <prerequisites>

--- a/cxf-xjc-plugin/src/main/java/org/apache/cxf/maven_plugin/XSDToJavaRunner.java
+++ b/cxf-xjc-plugin/src/main/java/org/apache/cxf/maven_plugin/XSDToJavaRunner.java
@@ -29,7 +29,6 @@ import java.net.URLClassLoader;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlElementRef;
 
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
@@ -51,6 +50,7 @@ import com.sun.tools.xjc.reader.internalizer.AbstractReferenceFinderImpl;
 import com.sun.tools.xjc.reader.internalizer.DOMForest;
 import com.sun.tools.xjc.reader.xmlschema.parser.XMLSchemaInternalizationLogic;
 
+import jakarta.xml.bind.annotation.XmlElementRef;
 import javassist.ClassPool;
 import javassist.CtClass;
 import javassist.CtMethod;
@@ -159,7 +159,7 @@ public class XSDToJavaRunner {
                 opt.classpaths.add(url);
             }
             if (checkXmlElementRef()) {
-                opt.target = SpecVersion.V2_1;
+                opt.target = SpecVersion.V2_3;
             }
             opt.setSchemaLanguage(Language.XMLSCHEMA);
             // set up the context class loader so that the user-specified plugin

--- a/dv-test/pom.xml
+++ b/dv-test/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
 

--- a/dv-test/src/test/java/org/apache/cxf/xjc/dv/DefaultValueTest.java
+++ b/dv-test/src/test/java/org/apache/cxf/xjc/dv/DefaultValueTest.java
@@ -25,16 +25,16 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBElement;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 import javax.xml.namespace.QName;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 
+import jakarta.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBElement;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.annotation.XmlElement;
+import jakarta.xml.bind.annotation.adapters.HexBinaryAdapter;
 import org.apache.cxf.configuration.foo.Foo;
 
 import org.junit.Assert;

--- a/dv/pom.xml
+++ b/dv/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/dv/src/main/java/org/apache/cxf/xjc/dv/DefaultValuePlugin.java
+++ b/dv/src/main/java/org/apache/cxf/xjc/dv/DefaultValuePlugin.java
@@ -25,8 +25,6 @@ import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.xml.bind.DatatypeConverter;
-import javax.xml.bind.annotation.adapters.HexBinaryAdapter;
 import javax.xml.datatype.DatatypeConfigurationException;
 import javax.xml.datatype.DatatypeFactory;
 import javax.xml.namespace.NamespaceContext;
@@ -63,6 +61,9 @@ import com.sun.xml.xsom.XSParticle;
 import com.sun.xml.xsom.XSTerm;
 import com.sun.xml.xsom.XSType;
 import com.sun.xml.xsom.XmlString;
+
+import jakarta.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.annotation.adapters.HexBinaryAdapter;
 
 /**
  * Modifies the JAXB code model to initialize fields mapped from schema elements 
@@ -202,7 +203,7 @@ public class DefaultValuePlugin {
                     String varName = f.getPropertyInfo().getName(false);
                     JFieldVar var = co.implClass.fields().get(varName);
                     if (var != null 
-                        && !"javax.xml.ws.wsaddressing.W3CEndpointReference".equals(f.getRawType().fullName())) {
+                        && !"jakarta.xml.ws.wsaddressing.W3CEndpointReference".equals(f.getRawType().fullName())) {
                         var.init(JExpr._new(f.getRawType()));
                     }
                 }
@@ -230,14 +231,14 @@ public class DefaultValuePlugin {
                     } else {
                         JType type = f.getRawType();
                         String typeName = type.fullName();
-                        if ("javax.xml.datatype.Duration".equals(typeName)) {
+                        if ("jakarta.xml.datatype.Duration".equals(typeName)) {
                             updateDurationGetter(co, f, co.implClass, xmlDefaultValue, outline);
                         }
                     }
                 } else if (null == dvExpr) {                    
                     JType type = f.getRawType();
                     String typeName = type.fullName();
-                    if ("javax.xml.datatype.Duration".equals(typeName)) {
+                    if ("jakarta.xml.datatype.Duration".equals(typeName)) {
                         updateDurationGetter(co, f, co.implClass, xmlDefaultValue, outline);
                     }
                 } else {
@@ -251,8 +252,8 @@ public class DefaultValuePlugin {
             JDefinedClass cls = po.objectFactoryGenerator().getObjectFactory();
             for (JMethod m : cls.methods()) {
                 String tn = m.type().fullName();
-                if (tn.startsWith("javax.xml.bind.JAXBElement<java.util.List<") 
-                    || tn.startsWith("javax.xml.bind.JAXBElement<byte[]>")) {
+                if (tn.startsWith("jakarta.xml.bind.JAXBElement<java.util.List<") 
+                    || tn.startsWith("jakarta.xml.bind.JAXBElement<byte[]>")) {
                     JBlock b = m.body();
                     
                     for (Object o : b.getContents()) {

--- a/javadoc/pom.xml
+++ b/javadoc/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
     
 

--- a/javadoc/src/test/resources/anonymousEnum-javadoc-bindings.xjb
+++ b/javadoc/src/test/resources/anonymousEnum-javadoc-bindings.xjb
@@ -17,10 +17,10 @@
  under the License.
  -->
  <jaxb:bindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
-	jaxb:version="2.1" schemaLocation="anonymousEnum.xsd"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	xmlns:xjc="https://jakarta.ee/xml/ns/jaxb/xjc"
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_2_0.xsd"
+	jaxb:version="3.0" schemaLocation="anonymousEnum.xsd"
 	node="/xs:schema">
 		
 	<jaxb:bindings node="./xs:element[@name='someElement']/xs:simpleType">

--- a/javadoc/src/test/resources/complexTypeWithDocumentedProperties-javadoc-bindings.xjb
+++ b/javadoc/src/test/resources/complexTypeWithDocumentedProperties-javadoc-bindings.xjb
@@ -17,10 +17,10 @@
  under the License.
  -->
  <jaxb:bindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
-	jaxb:version="2.1" schemaLocation="complexTypeWithDocumentedProperties.xsd"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	xmlns:xjc="https://jakarta.ee/xml/ns/jaxb/xjc"
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_2_0.xsd"
+	jaxb:version="3.0" schemaLocation="complexTypeWithDocumentedProperties.xsd"
 	node="//xs:complexType[@name='ComplexTypeWithDocumentedProperties']/xs:sequence/xs:element[@name='documentedElement']">
 	
 	<jaxb:property>

--- a/javadoc/src/test/resources/enumDocumented-javadoc-bindings.xjb
+++ b/javadoc/src/test/resources/enumDocumented-javadoc-bindings.xjb
@@ -17,10 +17,10 @@
  under the License.
  -->
  <jaxb:bindings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jaxb="http://java.sun.com/xml/ns/jaxb"
-	xmlns:xjc="http://java.sun.com/xml/ns/jaxb/xjc"
-	xsi:schemaLocation="http://java.sun.com/xml/ns/jaxb http://java.sun.com/xml/ns/jaxb/bindingschema_2_0.xsd"
-	jaxb:version="2.1" schemaLocation="enumDocumented.xsd"
+	xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb"
+	xmlns:xjc="https://jakarta.ee/xml/ns/jaxb/xjc"
+	xsi:schemaLocation="https://jakarta.ee/xml/ns/jaxb https://jakarta.ee/xml/ns/jaxb/bindingschema_2_0.xsd"
+	jaxb:version="3.0" schemaLocation="enumDocumented.xsd"
 	node="//xs:simpleType[@name='enumDocumented']">
 	
 	<jaxb:typesafeEnumClass>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <groupId>org.apache.cxf.xjc-utils</groupId>
     <artifactId>xjc-utils</artifactId>
     <packaging>pom</packaging>
-    <version>3.3.2-SNAPSHOT</version>
+    <version>4.0.0-SNAPSHOT</version>
     <name>Apache CXF XJC Utils</name>
     <url>https://cxf.apache.org</url>
 
@@ -46,7 +46,8 @@
     <properties>
         <cxf-buildtools-version>3.4.5-SNAPSHOT</cxf-buildtools-version>
         <jdk.version>1.8</jdk.version>
-        <jaxb-version>2.3.3</jaxb-version>
+        <jaxb-version>3.0.1</jaxb-version>
+        <jaxb-runtime-version>3.0.1</jaxb-runtime-version>
 
         <eclipse.outputDirectory>${basedir}/target/classes</eclipse.outputDirectory>
         <downloadSources>true</downloadSources>
@@ -95,17 +96,17 @@
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-runtime</artifactId>
-                <version>${jaxb-version}</version>
+                <version>${jaxb-runtime-version}</version>
             </dependency>
             <dependency>
                 <groupId>org.glassfish.jaxb</groupId>
                 <artifactId>jaxb-xjc</artifactId>
-                <version>${jaxb-version}</version>
+                <version>${jaxb-runtime-version}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.13.1</version>
+                <version>4.13.2</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.maven</groupId>
@@ -305,7 +306,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.6.0</version>
+                    <version>3.6.2</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/property-listener/pom.xml
+++ b/property-listener/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/property-listener/src/main/java/org/apache/cxf/xjc/property_listener/PropertyListenerPlugin.java
+++ b/property-listener/src/main/java/org/apache/cxf/xjc/property_listener/PropertyListenerPlugin.java
@@ -26,7 +26,6 @@ import java.lang.reflect.Modifier;
 import java.util.List;
 import java.util.logging.Logger;
 
-import javax.xml.bind.annotation.XmlTransient;
 
 import org.xml.sax.ErrorHandler;
 
@@ -41,6 +40,8 @@ import com.sun.codemodel.JVar;
 import com.sun.tools.xjc.Options;
 import com.sun.tools.xjc.outline.ClassOutline;
 import com.sun.tools.xjc.outline.Outline;
+
+import jakarta.xml.bind.annotation.XmlTransient;
 
 /**
  * Modifies the JAXB code model to add a PropertyChangeListener to the 

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <build>
@@ -30,7 +30,7 @@
                         <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
                         <Bundle-Description>${project.decription}</Bundle-Description>
                         <Import-Package>
-                            javax.xml.bind*;version="[2,3)",
+                            jakarta.xml.bind*;version="[3,4)",
                             *
                         </Import-Package>
                     </instructions>

--- a/runtime/src/main/java/org/apache/cxf/xjc/runtime/DataTypeAdapter.java
+++ b/runtime/src/main/java/org/apache/cxf/xjc/runtime/DataTypeAdapter.java
@@ -21,7 +21,7 @@ package org.apache.cxf.xjc.runtime;
 import java.util.Calendar;
 import java.util.Date;
 
-import javax.xml.bind.DatatypeConverter;
+import jakarta.xml.bind.DatatypeConverter;
 
 public final class DataTypeAdapter {
 

--- a/runtime/src/main/java/org/apache/cxf/xjc/runtime/JAXBToStringStyle.java
+++ b/runtime/src/main/java/org/apache/cxf/xjc/runtime/JAXBToStringStyle.java
@@ -19,10 +19,10 @@
 
 package org.apache.cxf.xjc.runtime;
 
-import javax.xml.bind.JAXBElement;
-
+import jakarta.xml.bind.JAXBElement;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
+
 
 /*
  * Override default styles to recognise JAXBElement as needing introspection

--- a/runtime/src/test/java/org/apache/cxf/xjc/runtime/JAXBElementToStringStyleTest.java
+++ b/runtime/src/test/java/org/apache/cxf/xjc/runtime/JAXBElementToStringStyleTest.java
@@ -20,9 +20,9 @@
 package org.apache.cxf.xjc.runtime;
 
 
-import javax.xml.bind.JAXBElement;
 import javax.xml.namespace.QName;
 
+import jakarta.xml.bind.JAXBElement;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 
 import org.junit.Assert;

--- a/ts-test/pom.xml
+++ b/ts-test/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
 

--- a/ts/pom.xml
+++ b/ts/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/wsdlextension-test/pom.xml
+++ b/wsdlextension-test/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/wsdlextension/pom.xml
+++ b/wsdlextension/pom.xml
@@ -27,7 +27,7 @@
     <parent>
         <groupId>org.apache.cxf.xjc-utils</groupId>
         <artifactId>xjc-utils</artifactId>
-        <version>3.3.2-SNAPSHOT</version>
+        <version>4.0.0-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/wsdlextension/src/main/java/org/apache/cxf/xjc/wsdlextension/WSDLExtension.java
+++ b/wsdlextension/src/main/java/org/apache/cxf/xjc/wsdlextension/WSDLExtension.java
@@ -23,8 +23,6 @@ import java.io.IOException;
 import java.util.logging.Logger;
 
 import javax.wsdl.extensions.ExtensibilityElement;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.namespace.QName;
 
 import org.xml.sax.ErrorHandler;
@@ -40,6 +38,9 @@ import com.sun.tools.xjc.BadCommandLineException;
 import com.sun.tools.xjc.Options;
 import com.sun.tools.xjc.outline.ClassOutline;
 import com.sun.tools.xjc.outline.Outline;
+
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlTransient;
 
 public class WSDLExtension {
 


### PR DESCRIPTION
The `xjc-utils` use the `javax` artifacts for code generation, it would make sense to branch off `4.0.0` (master) to support Jakarka artifacts and align with CXF plans to support Jakarta as well.

@dkulp @coheigea @amarkevich  if it makes sense for you, would be great to create maintenance branch for `3.2.x` and switch master to `4.0.0` / Jakarta, the same way we did for CXF, thank you guys!