### PR TITLE
CXFXJC-41: Regression with JAXB 2.3.5 / 3.x: http://schemas.xmlsoap.org/wsdl/ is not a part of this compilation

### DIFF
--- a/cxf-xjc-plugin/src/main/java/org/apache/cxf/maven_plugin/XSDToJavaRunner.java
+++ b/cxf-xjc-plugin/src/main/java/org/apache/cxf/maven_plugin/XSDToJavaRunner.java
@@ -124,7 +124,7 @@ public class XSDToJavaRunner {
                     if (resolved == null) {
                         return null;
                     }
-                    InputSource iSource = new InputSource(resolved);
+                    InputSource iSource = new InputSource((systemId != null) ? systemId : resolved);
                     iSource.setPublicId(publicId);
                     try {
                         final URL url;

--- a/cxf-xjc-plugin/src/test/java/org/apache/cxf/maven_plugin/XSDToJavaRunnerTest.java
+++ b/cxf-xjc-plugin/src/test/java/org/apache/cxf/maven_plugin/XSDToJavaRunnerTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.cxf.maven_plugin;
+
+import java.io.File;
+import java.util.Collections;
+
+import org.sonatype.plexus.build.incremental.BuildContext;  
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class XSDToJavaRunnerTest {
+    @Rule public TemporaryFolder outputFolder = new TemporaryFolder();
+    
+    @Test
+    public void testCatalogAndBindings() throws Exception {
+        final BuildContext context = new XJCBuildContext();
+        final XJCErrorListener listener = new XJCErrorListener(context);
+
+        final File outputFile = outputFolder.newFile();
+        final String xjb = getClass().getResource("/schemas/wsdl/test.xjb").toExternalForm();
+        final String xsd = getClass().getResource("/schemas/wsdl/test.xsd").toExternalForm();
+        final String catalog = getClass().getResource("/schemas/configuration/catalog.cat").toExternalForm();
+        
+        new XSDToJavaRunner(
+            new String [] {
+                "-catalog", catalog,
+                "-b", xjb,
+                xsd 
+            }, 
+            listener, 
+            outputFile, 
+            Collections.emptyList()).run();
+        
+        assertThat(listener.getFirstError(), is(nullValue()));
+    }
+}

--- a/cxf-xjc-plugin/src/test/resources/schemas/configuration/catalog.cat
+++ b/cxf-xjc-plugin/src/test/resources/schemas/configuration/catalog.cat
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+
+
+<catalog xmlns="urn:oasis:names:tc:entity:xmlns:xml:catalog">
+    <system systemId="http://schemas.xmlsoap.org/wsdl/" uri="wsdl.xsd"/>
+</catalog>

--- a/cxf-xjc-plugin/src/test/resources/schemas/configuration/wsdl.xsd
+++ b/cxf-xjc-plugin/src/test/resources/schemas/configuration/wsdl.xsd
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" ?> 
+<!-- 
+ 
+Copyright 2001 - 2005, International Business Machines Corporation and Microsoft Corporation
+All Rights Reserved
+
+License for WSDL Schema Files
+
+The Authors grant permission to copy and distribute the WSDL Schema 
+Files in any medium without fee or royalty as long as this notice and 
+license are distributed with them.  The originals of these files can 
+be located at:
+
+http://schemas.xmlsoap.org/wsdl/2004-08-24.xsd
+
+THESE SCHEMA FILES ARE PROVIDED "AS IS," AND THE AUTHORS MAKE NO REPRESENTATIONS 
+OR WARRANTIES, EXPRESS OR IMPLIED, REGARDING THESE FILES, INCLUDING, BUT NOT 
+LIMITED TO, WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, 
+NON-INFRINGEMENT OR TITLE.  THE AUTHORS WILL NOT BE LIABLE FOR ANY DIRECT, 
+INDIRECT, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF OR 
+RELATING TO ANY USE OR DISTRIBUTION OF THESE FILES.
+
+The name and trademarks of the Authors may NOT be used in any manner, 
+including advertising or publicity pertaining to these files or any program 
+or service that uses these files, written prior permission.  Title to copyright 
+in these files will at all times remain with the Authors.
+
+No other rights are granted by implication, estoppel or otherwise.
+
+
+--> 
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+           targetNamespace="http://schemas.xmlsoap.org/wsdl/"
+           elementFormDefault="qualified" >
+   
+  <xs:complexType mixed="true" name="tDocumentation" >
+    <xs:sequence>
+      <xs:any minOccurs="0" maxOccurs="unbounded" processContents="lax" />
+    </xs:sequence>
+  </xs:complexType>
+
+</xs:schema>

--- a/cxf-xjc-plugin/src/test/resources/schemas/wsdl/test.xjb
+++ b/cxf-xjc-plugin/src/test/resources/schemas/wsdl/test.xjb
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<jaxb:bindings version="3.0" 
+  xmlns:jaxb="https://jakarta.ee/xml/ns/jaxb" 
+  xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+  xmlns:xjc="https://jakarta.ee/xml/ns/jaxb/xjc" 
+  jaxb:extensionBindingPrefixes="xjc">
+    <jaxb:bindings schemaLocation="http://schemas.xmlsoap.org/wsdl/" node="/xs:schema">
+        <jaxb:schemaBindings>
+            <jaxb:package name="org.apache.cxf.wsdl"/>
+        </jaxb:schemaBindings>
+    </jaxb:bindings>
+</jaxb:bindings>

--- a/cxf-xjc-plugin/src/test/resources/schemas/wsdl/test.xsd
+++ b/cxf-xjc-plugin/src/test/resources/schemas/wsdl/test.xsd
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements. See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership. The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License. You may obtain a copy of the License at
+ 
+  http://www.apache.org/licenses/LICENSE-2.0
+ 
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied. See the License for the
+  specific language governing permissions and limitations
+  under the License.
+-->
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" 
+           targetNamespace="http://cxf.apache.org/abc/test" 
+           xmlns:tns="http://cxf.apache.org/abc/test" 
+           xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" 
+           elementFormDefault="qualified" 
+           attributeFormDefault="unqualified"> 
+
+    <xs:import namespace="http://schemas.xmlsoap.org/wsdl/" schemaLocation="http://schemas.xmlsoap.org/wsdl/"/>
+
+</xs:schema>


### PR DESCRIPTION
Interesting regression has been observed with JAXB 2.3.5 and 3.x: the CXF builds are failing with :

 
```
[ERROR] rt\wsdl\src\test\resources\schemas\wsdl\test-conf.xjb [25:88]: "http://schemas.xmlsoap.org/wsdl/" is not a part of this compilation. Is this a mistake for "file:core/src/main/resources/schemas/wsdl/wsdl.xsd"?                                                                                
com.sun.istack.SAXParseException2; systemId: file:/rt/wsdl/src/test/resources/schemas/wsdl/test-conf.xjb; lineNumber: 25; columnNumber: 88; "http://schemas.xmlsoap.org/wsdl/" is not a part of this compilation. Is this a mistake for "file:core/src/main/resources/schemas/wsdl/wsdl.xsd"?           
        at com.sun.tools.xjc.reader.internalizer.Internalizer.reportError(Internalizer.java:570)                                                                                                         
        at com.sun.tools.xjc.reader.internalizer.Internalizer.reportError(Internalizer.java:563)                                                                                                         
        at com.sun.tools.xjc.reader.internalizer.Internalizer.buildTargetNodeMap(Internalizer.java:206)                                                                                                  
        at com.sun.tools.xjc.reader.internalizer.Internalizer.buildTargetNodeMap(Internalizer.java:335)                                                                                                  
        at com.sun.tools.xjc.reader.internalizer.Internalizer.transform(Internalizer.java:116)                                                                                                           
        at com.sun.tools.xjc.reader.internalizer.Internalizer.transform(Internalizer.java:77)                                                                                                            
        at com.sun.tools.xjc.reader.internalizer.DOMForest.transform(DOMForest.java:429)                                                                                                                 
        at com.sun.tools.xjc.ModelLoader.buildDOMForest(ModelLoader.java:286)                                                                                                                            
        at com.sun.tools.xjc.ModelLoader.loadXMLSchema(ModelLoader.java:318)                                                                                                                             
        at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:121)                                                                                                                                      
        at com.sun.tools.xjc.ModelLoader.load(ModelLoader.java:76)                                                                                                                                       
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)                                                                                                                
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)                                                                                              
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)                                                                                      
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)                                                                                                                                    
        at org.apache.cxf.maven_plugin.XSDToJavaRunner.loadModel(XSDToJavaRunner.java:224)                                                                                                               
        at org.apache.cxf.maven_plugin.XSDToJavaRunner.run(XSDToJavaRunner.java:174)                                                                                                                     
        at org.apache.cxf.maven_plugin.XSDToJavaRunner.main(XSDToJavaRunner.java:360)                                                                                                                                                                                                         
        at org.apache.cxf.maven_plugin.XSDToJavaRunner.loadModel(XSDToJavaRunner.java:224)                                                                                                               
        at org.apache.cxf.maven_plugin.XSDToJavaRunner.run(XSDToJavaRunner.java:174)                                                                                                                     
        at org.apache.cxf.maven_plugin.XSDToJavaRunner.main(XSDToJavaRunner.java:360)                                                                                                                     
```

It turned out, it is related to the change of how `systemId` is being passed through: previously, it was passed along with the `InputSource` in `DOMForest` by calling this method:

```
    /**
     * Parses an XML at the given location (
     * and XMLs referenced by it) into DOM trees
     * and stores them to this forest.
     * 
     * @return the parsed DOM document object.
     */
    public Document parse( String systemId, boolean root ) throws SAXException, IOException {
        ... 
        // but we still use the original system Id as the key.
        return parse( systemId, is, root );
    } 
```

But the latest runtimes were changed to use this method instead:

```
    public Document parse( InputSource source, boolean root ) throws SAXException {
        if( source.getSystemId()==null )
            throw new IllegalArgumentException();
        
        return parse( source.getSystemId(), source, root );
    } 
```

As the result, the `systemId` was stopped to resolve in certain cases. I am working on adding the test case, but it is not trivial.
