### PR TITLE
CXFXJC-47: XJC DefaultValue plugin uses JAXBElement that does not have a default constructor

### DIFF
--- a/dv-test/pom.xml
+++ b/dv-test/pom.xml
@@ -73,7 +73,6 @@
                                     <xsd>${basedir}/src/test/resources/schemas/configuration/foo.xsd</xsd>
                                     <extensionArgs>
                                         <arg>-Xdv</arg>
-                                        <arg>-Xdv:excludedFromDefaultValueGeneration=jakarta.xml.bind.JAXBElement</arg>
                                     </extensionArgs>
                                 </xsdOption>
                             </xsdOptions>

--- a/dv-test/pom.xml
+++ b/dv-test/pom.xml
@@ -73,6 +73,7 @@
                                     <xsd>${basedir}/src/test/resources/schemas/configuration/foo.xsd</xsd>
                                     <extensionArgs>
                                         <arg>-Xdv</arg>
+                                        <arg>-Xdv:excludedFromDefaultValueGeneration=jakarta.xml.bind.JAXBElement</arg>
                                     </extensionArgs>
                                 </xsdOption>
                             </xsdOptions>

--- a/dv-test/src/test/resources/schemas/configuration/foo.xsd
+++ b/dv-test/src/test/resources/schemas/configuration/foo.xsd
@@ -147,5 +147,21 @@
       <xs:sequence>
         <xs:element minOccurs="0" name="redemptionNumber" type="xs:string" />
       </xs:sequence>
-    </xs:complexType>    
+    </xs:complexType>
+
+    <xs:element name="vehicle" type="tns:vehicle"/>
+    <xs:complexType name="vehicle" abstract="true"/>
+
+    <xs:complexType name="car">
+        <xs:complexContent>
+            <xs:extension base="tns:vehicle"/>
+        </xs:complexContent>
+    </xs:complexType>
+    <xs:element name="car" type="tns:car" substitutionGroup="tns:vehicle"/>
+
+    <xs:complexType name="trip">
+        <xs:sequence>
+            <xs:element ref="tns:vehicle"/>
+        </xs:sequence>
+    </xs:complexType>
 </xs:schema>


### PR DESCRIPTION
We've found a minor bug when using extensions and substitiongroups.
The defaultvalue-plugin generates a `new JAXBElement` expression, which isn't valid java code, as JAXBElement does not have a default constructor.
I've added a fix and a xsd-file for the corresponding test, to reproduce this bug.