### PR TITLE
[INFRA] Set up default rulesets for default and release branches

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,14 @@
+github:
+  rulesets:
+    - name: "Default Branch Protection"
+      type: branch
+      branches:
+        includes:
+          - "~DEFAULT_BRANCH"
+          - "release/*"
+          - "rel/*"
+        excludes: []
+      bypass_teams:
+        - root
+      restrict_deletion: true
+      restrict_force_push: true

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -6,7 +6,6 @@ github:
         includes:
           - "~DEFAULT_BRANCH"
           - "[0-9]+.[0-9]+.x-fixes"
-          - "rel/*"
         excludes: []
       bypass_teams:
         - root

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -5,7 +5,7 @@ github:
       branches:
         includes:
           - "~DEFAULT_BRANCH"
-          - "release/*"
+          - "\d+.\d+.x-fixes*"
           - "rel/*"
         excludes: []
       bypass_teams:

--- a/.asf.yaml
+++ b/.asf.yaml
@@ -5,7 +5,7 @@ github:
       branches:
         includes:
           - "~DEFAULT_BRANCH"
-          - "\d+.\d+.x-fixes*"
+          - "[0-9]+.[0-9]+.x-fixes"
           - "rel/*"
         excludes: []
       bypass_teams:


### PR DESCRIPTION
This Pull Request enables the repository to conform with the "sane default security settings" of the Apache Software Foundation by configuring a default branch ruleset that protects the default branch and any release branches.

Note that `~DEFAULT_BRANCH` is a GitHub symbolic link to the current default branch (HEAD) of the repository and does not need changing.
If the managing project does not wish to set up these defaults, please close this Pull Request. Alternatively, the project may merge this Pull Request to apply the changes immediately.

If no action is taken, this Pull Request will be automatically merged by the Apache Infrastructure team on **2026-06-14** (30 days from now).

For any further information, please reach us on Slack or at: users@infra.apache.org
