### PR TITLE
Add SECURITY.md + AGENTS.md pointing at the CXF umbrella threat model for discoverability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,29 @@
+<!--
+SPDX-License-Identifier: Apache-2.0
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Agent Guide for cxf-xjc-utils
+
+This file is read by automated agents (security scanners, code analyzers,
+AI assistants) operating on this repository.
+
+## Security
+
+Security model: [SECURITY.md](./SECURITY.md) -> the Apache CXF umbrella threat
+model at https://github.com/apache/cxf/blob/main/THREAT_MODEL.md
+
+This repository is build-time XJC (XML Schema to Java) tooling and Maven plugins for Apache CXF — build-time tooling, not a runtime service. It is
+placed out of the runtime threat model by the Apache CXF umbrella model linked
+above; agents should consult that document before reporting issues.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,18 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+For how to report a security problem, see [the ASF security process](https://www.apache.org/security/).
+Apache CXF's existing security advisories are published at <https://cxf.apache.org/security-advisories.html>.
+Please do **not** open public GitHub issues or pull requests for security reports.
+
+## Threat Model
+
+`apache/cxf-xjc-utils` is build-time XJC (XML Schema to Java) tooling and Maven plugins for Apache CXF. It runs at build time and is not a runtime service, so it has no runtime threat
+model of its own; its security context is covered by the **Apache CXF umbrella threat model**, which places
+build-time tooling outside the runtime model:
+
+  https://github.com/apache/cxf/blob/main/THREAT_MODEL.md
+
+Reporters and triagers should consult that document (in particular its scope / out-of-scope sections)
+alongside this policy.


### PR DESCRIPTION
**This is a proposal for the CXF PMC to review — please correct, reject, or discuss as needed.**

`apache/cxf-xjc-utils` is build-time XJC (XML Schema to Java) tooling and Maven plugins for Apache CXF. This PR adds a `SECURITY.md` and `AGENTS.md` so an automated scan agent can mechanically discover the project's security model via `AGENTS.md -> SECURITY.md -> model`. Because this repo is build-time tooling rather than a runtime service, both files point at the **Apache CXF umbrella threat model** (https://github.com/apache/cxf/blob/main/THREAT_MODEL.md), which scopes build-time tooling out of the runtime model — rather than duplicating a model here.

Context: the ASF Security team is preparing the project for an automated agentic security scan we're piloting; a discoverable model (even a pointer to the umbrella) is what lets the scan resolve scope. The umbrella model is proposed separately in apache/cxf. Questions/pushback welcome.
